### PR TITLE
Ensure follower units wait for operator user

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -283,6 +283,11 @@ class RabbitMQOperatorCharm(CharmBase):
             event.defer()
             return
 
+        # Ensure operator user is created
+        if not self.unit.is_leader() and not self.peers.operator_user_created:
+            event.defer()
+            return
+
         # Wait for the peers binding address to be ready before configuring
         # the rabbit environment. This is due to rabbitmq-env.conf needing
         # the unit address for peering.


### PR DESCRIPTION
When the charm is deployed with multiple units, it may try to use the guest on the follower units while they should wait for the operator user to be created on the leader and use it.

Closes-Bug: #2120540