### PR TITLE
Feat/cluster name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -364,6 +364,7 @@ class RabbitMQOperatorCharm(CharmBase):
                 logging.info("RabbitMQ started")
 
         _check_rmq_running()
+        self._ensure_cluster_name()
         self._on_update_status(event)
         self._reconcile_lb(None)
 
@@ -838,6 +839,11 @@ class RabbitMQOperatorCharm(CharmBase):
         return self.peers.operator_password
 
     @property
+    def cluster_name(self) -> str:
+        """Cluster name exposed by RabbitMQ."""
+        return f"{self.model.name}-{self.app.name}"
+
+    @property
     def rabbit_running(self) -> bool:
         """Check whether RabbitMQ is running by accessing its API."""
         try:
@@ -853,6 +859,28 @@ class RabbitMQOperatorCharm(CharmBase):
         except requests.exceptions.ConnectionError:
             return False
         return True
+
+    def _ensure_cluster_name(self) -> None:
+        """Ensure a stable cluster name is configured for this deployment."""
+        if not self.unit.is_leader():
+            return
+
+        try:
+            api = self._get_admin_api()
+            if api.get_cluster_name() == self.cluster_name:
+                return
+            api.set_cluster_name(self.cluster_name)
+        except requests.exceptions.ConnectionError as e:
+            logger.warning(
+                "RabbitMQ not ready to reconcile cluster name yet: %s", e
+            )
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code == 401:
+                logger.warning(
+                    "RabbitMQ auth not ready to reconcile cluster name yet"
+                )
+                return
+            raise
 
     def _get_admin_api(
         self, username: str = None, password: str = None

--- a/src/rabbit_extended_api.py
+++ b/src/rabbit_extended_api.py
@@ -30,6 +30,17 @@ import rabbitmq_admin
 class ExtendedAdminApi(rabbitmq_admin.AdminAPI):
     """Extend rabbitmq_admin.AdminAPI to cover missing endpoints the charm needs."""
 
+    def get_cluster_name(self) -> str | None:
+        """Return the RabbitMQ cluster name."""
+        return self._api_get("/api/overview").get("cluster_name")
+
+    def set_cluster_name(self, cluster_name: str) -> None:
+        """Set the RabbitMQ cluster name."""
+        self._api_put(
+            "/api/global-parameters/cluster_name",
+            data={"value": cluster_name},
+        )
+
     def list_queues(self):
         """A list of queues."""
         return self._api_get("/api/queues")

--- a/tests/unit/test_charm_scenario.py
+++ b/tests/unit/test_charm_scenario.py
@@ -20,6 +20,7 @@ from unittest.mock import (
 
 import ops.model
 import ops.pebble
+import requests
 from ops import (
     testing,
 )
@@ -180,6 +181,36 @@ def test_config_changed_proceeds_for_leader_without_operator_user(
     assert state_out.deferred == []
 
 
+def test_config_changed_leader_updates_cluster_name(
+    ctx, rabbitmq_container, networks, monkeypatch
+):
+    """The leader updates the RabbitMQ cluster name during config-changed."""
+    peer = testing.PeerRelation(
+        endpoint="peers",
+        local_app_data={
+            "operator_password": "foobar",
+            "erlang_cookie": "magicsecurity",
+        },
+        local_unit_data={},
+    )
+    state = _state(rabbitmq_container, networks, leader=True, relations=[peer])
+    admin_api = Mock(
+        get_cluster_name=Mock(return_value="rabbit@rabbitmq-k8s-0"),
+        set_cluster_name=Mock(),
+        list_quorum_queues=Mock(return_value=[]),
+    )
+
+    with ctx(ctx.on.config_changed(), state) as manager:
+        _patch_config_changed_for_success(
+            monkeypatch, manager.charm, admin_api=admin_api
+        )
+        manager.run()
+
+    admin_api.set_cluster_name.assert_called_once_with(
+        f"{manager.charm.model.name}-{manager.charm.app.name}"
+    )
+
+
 def test_config_changed_proceeds_for_non_leader_with_operator_user(
     ctx, rabbitmq_container, networks, monkeypatch
 ):
@@ -202,6 +233,70 @@ def test_config_changed_proceeds_for_non_leader_with_operator_user(
         state_out = manager.run()
 
     assert state_out.deferred == []
+
+
+def test_config_changed_leader_tolerates_cluster_name_auth_race(
+    ctx, rabbitmq_container, networks, monkeypatch
+):
+    """Cluster-name reconciliation should not fail config-changed on early 401s."""
+    peer = testing.PeerRelation(
+        endpoint="peers",
+        local_app_data={
+            "operator_password": "foobar",
+            "operator_user_created": "rmqadmin",
+            "erlang_cookie": "magicsecurity",
+        },
+        local_unit_data={},
+    )
+    state = _state(rabbitmq_container, networks, leader=True, relations=[peer])
+    response = requests.Response()
+    response.status_code = 401
+    http_error = requests.exceptions.HTTPError(response=response)
+    admin_api = Mock(
+        get_cluster_name=Mock(side_effect=http_error),
+        set_cluster_name=Mock(),
+        list_quorum_queues=Mock(return_value=[]),
+    )
+
+    with ctx(ctx.on.config_changed(), state) as manager:
+        _patch_config_changed_for_success(
+            monkeypatch, manager.charm, admin_api=admin_api
+        )
+        state_out = manager.run()
+
+    assert state_out.deferred == []
+    admin_api.set_cluster_name.assert_not_called()
+
+
+def test_config_changed_non_leader_skips_cluster_name_update(
+    ctx, rabbitmq_container, networks, monkeypatch
+):
+    """Non-leader units do not update the RabbitMQ cluster name."""
+    peer = testing.PeerRelation(
+        endpoint="peers",
+        local_app_data={
+            "operator_password": "foobar",
+            "operator_user_created": "rmqadmin",
+            "erlang_cookie": "magicsecurity",
+        },
+        local_unit_data={},
+    )
+    state = _state(
+        rabbitmq_container, networks, leader=False, relations=[peer]
+    )
+    admin_api = Mock(
+        get_cluster_name=Mock(return_value="rabbit@rabbitmq-k8s-0"),
+        set_cluster_name=Mock(),
+        list_quorum_queues=Mock(return_value=[]),
+    )
+
+    with ctx(ctx.on.config_changed(), state) as manager:
+        _patch_config_changed_for_success(
+            monkeypatch, manager.charm, admin_api=admin_api
+        )
+        manager.run()
+
+    admin_api.set_cluster_name.assert_not_called()
 
 
 def test_config_changed_defers_without_erlang_cookie(


### PR DESCRIPTION
Set the RabbitMQ cluster name to "{model}-{app}" from the leader
once the broker is up.

This is used to avoid per-node "cluster" splits in observability and
Grafana dashboards. RabbitMQ documents cluster_name as cluster metadata,
which is announced to clients and recommended for Prometheus-based
monitoring, rather than as node identity or queue placement state.
That is why we believe this is acceptable for running deployments,
including those using quorum queues.

Docs:
https://www.rabbitmq.com/docs/4.1/prometheus
https://www.rabbitmq.com/docs/4.0/man/rabbitmqctl.8


depends-on:
- [x] #13 