### PR TITLE
Add s390x support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,6 +8,7 @@ links:
 base: ubuntu@24.04
 platforms:
   amd64:
+  s390x:
 
 config:
   options:
@@ -193,8 +194,11 @@ parts:
       - update-certificates
     build-packages:
       - git
+      - gcc
       - libffi-dev
+      # s390x: build cryptography (openssl-sys/Rust) from source
       - libssl-dev
+      - pkg-config
       - rustc-1.80
       - cargo-1.80
     charm-binary-python-packages:


### PR DESCRIPTION
Add s390x to platforms and ensure the charm part can build the
cryptography Python package from source on s390x, where no
prebuilt manylinux wheels are available on PyPI.

cryptography's Rust openssl-sys crate uses pkg-config to locate
libssl, so add pkg-config (plus gcc) to build-packages alongside
the existing libssl-dev, libffi-dev, rustc, and cargo. This
mirrors the proven s390x build configuration in sunbeam-charms.

Signed-off-by: Myles Penner <myles.penner@canonical.com>